### PR TITLE
Remove trailing slash from path

### DIFF
--- a/Route.php
+++ b/Route.php
@@ -27,8 +27,8 @@ class Route{
     // Parse current url
     $parsed_url = parse_url($_SERVER['REQUEST_URI']);//Parse Uri
 
-    if(isset($parsed_url['path'])){
-      $path = $parsed_url['path'];
+    if(isset($parsed_url['path']) && $parsed_url['path'] != '/'){
+      $path = rtrim($parsed_url['path'], '/');
     }else{
       $path = '/';
     }


### PR DESCRIPTION
Remove trailing slash from path (unless it's the root slash) before matching against routes. This ensures that both "/events" and "/events/" are matched with the route "/events"