### PR TITLE
Added option to define routes with multiple allowed methods

### DIFF
--- a/Route.php
+++ b/Route.php
@@ -27,8 +27,8 @@ class Route{
     // Parse current url
     $parsed_url = parse_url($_SERVER['REQUEST_URI']);//Parse Uri
 
-    if(isset($parsed_url['path'])){
-      $path = $parsed_url['path'];
+    if(isset($parsed_url['path']) && $parsed_url['path'] != '/'){
+      $path = rtrim($parsed_url['path'], '/');
     }else{
       $path = '/';
     }

--- a/Route.php
+++ b/Route.php
@@ -66,21 +66,24 @@ class Route{
 
         $path_match_found = true;
 
-        // Check method match
-        if(strtolower($method) == strtolower($route['method'])){
+        // Cast allowed method to array if it's not one already, then run through all methods
+        foreach ((array)$route['method'] as $allowedMethod) {
+            // Check method match
+            if(strtolower($method) == strtolower($allowedMethod)){
 
-          array_shift($matches);// Always remove first element. This contains the whole string
+                array_shift($matches);// Always remove first element. This contains the whole string
 
-          if($basepath!=''&&$basepath!='/'){
-            array_shift($matches);// Remove basepath
-          }
+                if($basepath!=''&&$basepath!='/'){
+                    array_shift($matches);// Remove basepath
+                }
 
-          call_user_func_array($route['function'], $matches);
+                call_user_func_array($route['function'], $matches);
 
-          $route_match_found = true;
+                $route_match_found = true;
 
-          // Do not check other routes
-          break;
+                // Do not check other routes
+                break;
+            }
         }
       }
     }

--- a/Route.php
+++ b/Route.php
@@ -6,6 +6,13 @@ class Route{
   private static $pathNotFound = null;
   private static $methodNotAllowed = null;
 
+  /**
+    * Function used to add a new route
+    * @param string $expression    Route string or expression
+    * @param callable $function    Function to call when route with allowed method is found
+    * @param string|array $method  Either a string of allowed method or an array with string values
+    *
+    */
   public static function add($expression, $function, $method = 'get'){
     array_push(self::$routes,Array(
       'expression' => $expression,

--- a/index.php
+++ b/index.php
@@ -11,6 +11,7 @@ function navi () {
 	  <li><a href="/foo/5/bar">foo 5 bar</a></li>
 	  <li><a href="/foo/bar/foo/bar">long route example</a></li>
 	  <li><a href="/contact-form">contact form</a></li>
+	  <li><a href="/get-post-sample">get+post example</a></li>
 	  <li><a href="/test.html">test.html</a></li>
 	  <li><a href="/aTrailingSlashDoesNotMatters">aTrailingSlashDoesNotMatters</a></li>
 	  <li><a href="/aTrailingSlashDoesNotMatters/">aTrailingSlashDoesNotMatters/</a></li>
@@ -43,7 +44,7 @@ Route::add('/test.html',function(){
   echo 'Hello from test.html';
 });
 
-// Post route example
+// Get route example
 Route::add('/contact-form',function(){
   navi();
   echo '<form method="post"><input type="text" name="test" /><input type="submit" value="send" /></form>';
@@ -55,6 +56,17 @@ Route::add('/contact-form',function(){
   echo 'Hey! The form has been sent:<br/>';
   print_r($_POST);
 },'post');
+
+// Get and Post route example
+Route::add('/get-post-sample',function(){
+  navi();
+	echo 'You can GET this page and also POST this form back to it';
+	echo '<form method="post"><input type="text" name="input" /><input type="submit" value="send" /></form>';
+	if(isset($_POST["input"])){
+		echo 'I also received a POST with this data:<br/>';
+		print_r($_POST);
+	}
+},['get','post']);
 
 // Route with regexp parameter
 // Be aware that (.*) will match / (slash) too. For example: /user/foo/bar/edit

--- a/index.php
+++ b/index.php
@@ -44,7 +44,7 @@ Route::add('/test.html',function(){
   echo 'Hello from test.html';
 });
 
-// Get route example
+// Post route example
 Route::add('/contact-form',function(){
   navi();
   echo '<form method="post"><input type="text" name="test" /><input type="submit" value="send" /></form>';


### PR DESCRIPTION
Sometimes it might be needed to allow multiple methods on a route (for ex. an admin page edit form, where the forms POST request is handled by the same page itself).
My proposed solution allows to define one allowed method by passing a string or multiple methods when passing an array of strings. Not passing any methods defaults to GET as before. This is also backwards compatible with any previous routes.
See included sample in index.php