### PR TITLE
fix regex  to support for non english letters

### DIFF
--- a/src/Steampixel/Route.php
+++ b/src/Steampixel/Route.php
@@ -57,7 +57,9 @@ class Route {
         }
   	  }
     }
-
+    
+  	$path = urldecode($path);
+    
     // Get current request method
     $method = $_SERVER['REQUEST_METHOD'];
 
@@ -81,7 +83,7 @@ class Route {
       $route['expression'] = $route['expression'].'$';
 
       // Check path match
-      if (preg_match('#'.$route['expression'].'#'.($case_matters ? '' : 'i'), $path, $matches)) {
+      if (preg_match('#'.$route['expression'].'#'.($case_matters ? '' : 'iu'), $path, $matches)) {
         $path_match_found = true;
 
         // Cast allowed method to array if it's not one already, then run through all methods


### PR DESCRIPTION
fix regex  to support for non english letters
like arabic
example:
http://domain.com/dance/الرقص-العربي

```
Route::add( '/([\d\w\._]+)/([\p{L}\d\-]+)', function($cat, $slug) {
	// do something
});
```